### PR TITLE
Fix dynamic linking + bump to version 3.5.1

### DIFF
--- a/pkgs/godot/default.nix
+++ b/pkgs/godot/default.nix
@@ -1,8 +1,10 @@
 { stdenv,
   lib,
   autoPatchelfHook,
+  makeWrapper,
   fetchurl,
   unzip,
+  udev,
   alsaLib, libXcursor, libXinerama, libXrandr, libXrender, libX11, libXi,
   libpulseaudio, libGL,
 }:
@@ -13,16 +15,17 @@ in
 
 stdenv.mkDerivation rec {
   pname = "godot-bin";
-  version = "3.3.2";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "https://downloads.tuxfamily.org/godotengine/${version}/Godot_v${version}-${qualifier}_x11.64.zip";
-    sha256 = "0sracw2b9ymjg3ypng3020fy8m0hpp7fhzmni89f73k4mssib020";
+    sha256 = "kl5HGjL2mjxWktfubJXan/l7bmZu562VmD8iO6rQ4H0=";
   };
 
-  nativeBuildInputs = [autoPatchelfHook unzip];
+  nativeBuildInputs = [autoPatchelfHook makeWrapper unzip];
 
   buildInputs = [
+    udev
     alsaLib
     libXcursor
     libXinerama
@@ -34,10 +37,17 @@ stdenv.mkDerivation rec {
     libGL
   ];
 
+  libraries = lib.makeLibraryPath buildInputs;
+
   unpackCmd = "unzip $curSrc -d source";
   installPhase = ''
     mkdir -p $out/bin
     install -m 0755 Godot_v${version}-${qualifier}_x11.64 $out/bin/godot
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/godot \
+      --set LD_LIBRARY_PATH ${libraries}
   '';
 
   meta = {

--- a/pkgs/godot/headless.nix
+++ b/pkgs/godot/headless.nix
@@ -8,15 +8,20 @@ in
 
 godotBin.overrideAttrs (oldAttrs: rec {
   pname = "godot-headless-bin";
-  version = "3.3.2";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "https://downloads.tuxfamily.org/godotengine/${version}/Godot_v${version}-${qualifier}_linux_headless.64.zip";
-    sha256 = "0i4g7329929jf4zyrivxnh6p17vygjj6hb2f5vjc4xzdpsn68ydk";
+    sha256 = "NgrJetf/EPYW64pix/+8PRrna0QlvnsA2tbdqjpEFHY=";
   };
 
   installPhase = ''
     mkdir -p $out/bin
     install -m 0755 Godot_v${version}-${qualifier}_linux_headless.64 $out/bin/godot-headless
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/godot-headless \
+      --set LD_LIBRARY_PATH ${oldAttrs.libraries}
   '';
 })

--- a/pkgs/godot/mono.nix
+++ b/pkgs/godot/mono.nix
@@ -12,11 +12,11 @@ in
 
 godotBin.overrideAttrs (oldAttrs: rec {
   pname = "godot-mono-bin";
-  version = "3.3.2";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "https://downloads.tuxfamily.org/godotengine/${version}/mono/Godot_v${version}-${qualifier}_mono_x11_64.zip";
-    sha256 = "036i3hqlabk736pg9l7qraj5mq2jdg9gfka7g22fyrr3hvz8jv4a";
+    sha256 = "7phG4vgq4m0h92gCMPv5kehQQ1BH7rS1c5VZ6Dx3WPc=";
   };
 
   buildInputs = oldAttrs.buildInputs ++ [zlib];
@@ -29,5 +29,10 @@ godotBin.overrideAttrs (oldAttrs: rec {
     cp -r GodotSharp $out/opt/godot-mono
 
     ln -s $out/opt/godot-mono/Godot_v${version}-${qualifier}_mono_x11.64 $out/bin/godot-mono
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/godot-mono \
+      --set LD_LIBRARY_PATH ${oldAttrs.libraries}
   '';
 })


### PR DESCRIPTION
+ Create a wrapper that sets `LD_LIBRARY_PATH` so `pulseaudio` and `alsa` are properly linked at runtime:
This fixes godot failing to load the audio driver and falling back to dummy.
Also link `udev` for controller hotplugging.

+ Update to Godot `3.5.1`